### PR TITLE
Fix typo/spelling: plural of menu is menus not menu's

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![BUNDLEPHOBIA](https://badgen.net/bundlephobia/minzip/react-laag)](https://bundlephobia.com/result?p=react-laag)
 [![Weekly downloads](https://badgen.net/npm/dw/react-laag)](https://badgen.net/npm/dw/react-laag)
 
-Primitives to build things like tooltips, dropdown menu's and pop-overs.
+Primitives to build things like tooltips, dropdown menus and pop-overs.
 
 Basically any kind of layer that can be toggled. Focus on **what** your layer should look like, and let react-laag take care of **where** and **when** to show it.
 
@@ -19,7 +19,7 @@ Visit the website for more examples and docs
 
 ## Features
 
-- [x] Build your own tooltips / dropdown-menu's / pop-overs / etc...
+- [x] Build your own tooltips / dropdown-menus / pop-overs / etc...
 - [x] Not opinionated regarding styling or animations
 - [x] Highly customizable
 - [x] Small footprint (tree-shakable)

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -9,10 +9,10 @@ const path = require("path");
 module.exports = {
   siteMetadata: {
     titlePostfix:
-      "- react-laag | Primitives to build things like tooltips, dropdown menu's and popovers in React",
+      "- react-laag | Primitives to build things like tooltips, dropdown menus and popovers in React",
     author: "react-laag",
     description:
-      "Primitives to build things like tooltips, dropdown menu's and popovers",
+      "Primitives to build things like tooltips, dropdown menus and popovers",
     siteUrl: "https://www.react-laag.com",
     keywords: ["react", "layer", "tooltip", "popover", "dropdown", "menu"],
     image: "/logo.png"

--- a/docs/src/components/ExamplesNav/index.js
+++ b/docs/src/components/ExamplesNav/index.js
@@ -133,7 +133,7 @@ export default function NavLeft() {
             </Item>
             <Item>
               <Link activeClassName="active" to="/examples/contextmenu/">
-                Nested context menu's
+                Nested context menus
               </Link>
             </Item>
             <Item>

--- a/docs/src/pages/docs/arrow.js
+++ b/docs/src/pages/docs/arrow.js
@@ -14,7 +14,7 @@ export default function Arrow() {
       <p>
         <code>{`<Arrow />`}</code> is a utility component that is useful if you
         want to add an arrow to your layer. This is a common practice for
-        especially tooltips, as well as menu's. The <code>{`<Arrow />`}</code>{" "}
+        especially tooltips, as well as menus. The <code>{`<Arrow />`}</code>{" "}
         component composes a svg dynamically based on a couple of props you
         provide. The goal is to add arrow functionality in a declarative way,
         without the need to do any arrow specific calculations.

--- a/docs/src/pages/docs/index.js
+++ b/docs/src/pages/docs/index.js
@@ -45,7 +45,7 @@ export default function Docs() {
       <h2>Where is it good for?</h2>
       <p>
         react-laag exposes primitives to build things like tooltips, dropdown
-        menu's and pop-overs in React. Basically any kind of layer that can be
+        menus and pop-overs in React. Basically any kind of layer that can be
         toggled. The keyword here is <b>primitive</b>. It's <i>not</i> a library
         with components that can be instantly used in your app, but more in the
         spirit of tools like <i>react-beautiful-dnd</i> and <i>downshift</i>,

--- a/docs/src/pages/docs/resources.js
+++ b/docs/src/pages/docs/resources.js
@@ -25,7 +25,7 @@ export default function Resources() {
             target="_blank"
             href="https://www.erikverweij.dev/blog/circular-menus-with-react-laag-framer-motion/"
           >
-            Circular menu's with react-laag and Framer Motion
+            Circular menus with react-laag and Framer Motion
           </a>
         </li>
         <li>
@@ -34,7 +34,7 @@ export default function Resources() {
             target="_blank"
             href="https://dev.to/everweij/accessible-and-adaptive-select-menu-s-using-react-laag-and-downshift-abn"
           >
-            Accessible and adaptive select menu's using react-laag and downshift
+            Accessible and adaptive select menus using react-laag and downshift
           </a>
         </li>
       </ul>

--- a/docs/src/pages/docs/usetogglelayer.js
+++ b/docs/src/pages/docs/usetogglelayer.js
@@ -25,7 +25,7 @@ export default function UseToggleLayer() {
         source to tie the layer to). In such cases it is recommended to use{" "}
         <code>{`useToggleLayer()`}</code>.<br />
         <br />
-        Common use cases: <i>context-menu's</i>, <i>text-selection</i>.
+        Common use cases: <i>context-menus</i>, <i>text-selection</i>.
       </p>
 
       <div className="label">Type</div>

--- a/docs/src/pages/examples/contextmenu.js
+++ b/docs/src/pages/examples/contextmenu.js
@@ -6,11 +6,11 @@ import Example from "../../examples/ContextMenu";
 
 export default function ContextMenu() {
   return (
-    <Main title="Nested context menu's" pageUrl="/examples/contextmenu/">
+    <Main title="Nested context menus" pageUrl="/examples/contextmenu/">
       <p>Right-click in the grey box to show the menu</p>
       <a href="https://codesandbox.io/s/nested-context-menus-xx52d?fontsize=14">
         <img
-          alt="Edit nested-context-menu's"
+          alt="Edit nested-context-menus"
           src="https://codesandbox.io/static/img/play-codesandbox.svg"
         />
       </a>

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -70,7 +70,7 @@ export default () => {
         <img alt="react-laag logo" src={logo} />
         <Title style={{ marginTop: 8, marginBottom: 48 }}>react-laag</Title>
         <h2 style={{ marginBottom: 16 }}>
-          Primitives to build things like tooltips, dropdown menu's and
+          Primitives to build things like tooltips, dropdown menus and
           pop-overs
         </h2>
         <Motto>


### PR DESCRIPTION
Thanks for the great library.

Merge request corrects the spelling of "menus".