### PR TITLE
Fix "useOutsideClick" dep array.

### DIFF
--- a/src/ToggleLayer/ToggleLayer.tsx
+++ b/src/ToggleLayer/ToggleLayer.tsx
@@ -243,7 +243,7 @@ function ToggleLayer({
       if (closeOnOutsideClick && !isSet(isOpenExternal)) {
         setOpenInternal(false);
       }
-    }, [isOpen, setOpenInternal, isOpenExternal])
+    }, [isOpen, setOpenInternal, isOpenExternal, onOutsideClick])
   );
 
   const containerElement =


### PR DESCRIPTION
This PR fixes a problem, where `onOutsideClick` callback doesn't have access to correct `state` / `props` values when changes happen while layer is open.

I've created a simple example representing the issue:
https://codesandbox.io/s/kind-elgamal-0njqm
