### PR TITLE
Add Controlled state to useToggleLayer.

### DIFF
--- a/src/ToggleLayer/ToggleLayer.tsx
+++ b/src/ToggleLayer/ToggleLayer.tsx
@@ -41,10 +41,7 @@ type RenderChildrenProps = {
 export type ToggleLayerProps = {
   children: (childrenProps: RenderChildrenProps) => React.ReactNode;
   renderLayer: RenderLayer;
-  isOpen?: boolean;
-  onOutsideClick?: () => void;
-  onDisappear?: (type: DisappearType) => void;
-} & ToggleLayerOptions;
+} & Omit<ToggleLayerOptions, "triggerRef">;
 
 export const ToggleLayer = ({
   children,

--- a/src/ToggleLayer/ToggleLayer.tsx
+++ b/src/ToggleLayer/ToggleLayer.tsx
@@ -3,7 +3,6 @@ import {
   LayerSide,
   RenderLayer,
   ToggleLayerOptions,
-  DisappearType
 } from "./types";
 
 import useOutsideClick, { OutsideClickGroupProvider } from "./useOutsideClick";

--- a/src/ToggleLayer/types.ts
+++ b/src/ToggleLayer/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 
-export type {ToggleLayerProps} from './ToggleLayer';
-export type {ArrowProps} from './Arrow';
+export type { ToggleLayerProps } from './ToggleLayer';
+export type { ArrowProps } from './Arrow';
 
 /**
  * Client Rect stuff
@@ -92,10 +92,14 @@ export type Container = HTMLElement | (() => HTMLElement);
 export type ToggleLayerOptions = {
   placement?: Placement;
   onStyle?: OnStyle;
+  isOpen?: boolean;
   closeOnOutsideClick?: boolean;
   closeOnDisappear?: DisappearType;
+  onOutsideClick?: () => void;
+  onDisappear?: (type: DisappearType) => void;
   ResizeObserver?: any;
   fixed?: boolean;
   container?: Container;
   environment?: Window;
+  triggerRef?: React.MutableRefObject<any>;
 };


### PR DESCRIPTION
Allow passing triggerRef when controlled. Issues #38 (Hack fix, I fix what I need and I could test, not fully resolve)
Adjust type, Omit triggerRef in ToggleLayer due to not been tested.
Fix openFromRef where ClientRect is not updated after scroll or resize. Issues #40 

## Question :
I want to talk about the open, toggle and close function in RenderChildrenProps in ToggleLayer. I understand that if your controlling the layer from outside, you shouldn't be able to do those which is understandable, but because it throw error if isOpenExternal is set, it force dev to protect their function if they allow to controlled the state. 
This is the useToggleLayer version, but it apply to ToggleLayer too.
``` Typescript
const protectedClose = () => {
  if(!isShown){
    toggleLayerProps.close()
    handleFocus()
  }
}
const protectedToggle = () => {
  if (!isShown && !toggleLayerProps.isOpen) {
    toggleLayerProps.openFromRef(targetRef)
  } else {
    protectedClose()
  }
}
``` 
I kinda think this error handle in ToggleLayer do more bad than good :
``` Typescript
if (isSet(isOpenExternal)) {
  throw new Error(
    "You cannot call `open()|close()|toggle()` while using the `isOpen` prop"
  );
}
```
If I want to controlled, I could said that my isOpenExternal is my "Always on top" feature and if it's disable, I can show it like a normal ToggleLayer, but with this error, you cannot... 
That been said, I didn't add the error in useToggleLayer in the open function now that I allow it to be controlled, because of this reason.

## Note :
I didn't include the triggerRef props in ToggleLayer because I had no code that could test if it work. Here what I would have add, but because I couldn't test it, I omit it and the type triggerRef in ToggleLayerProps.
``` Typescript
React.useEffect(() => {
  triggerRefExternal = triggerRef
}, [triggerRef]);
```
Why I only change useToggleLayer : I'm developing some Layout Primitive component. Something similar to [Evergreen Pane](https://evergreen.segment.com/components/layout-primitives/) and I'm restricted to a styling library which is something I shouldn't change, because it can affect much more than what I want to do. So I'm trying to omit the more element I can because the CSS has a lot of > selector and adding a Tooltip element to hold the ref break CSS. So I try to forwardRef and ToggleLayer give me this error **Error: Could not find a valid reference of the trigger element. See https://www.react-laag.com/docs/togglelayer/#children for more info.** or this one when it wasn't ToggleLayer : https://reactjs.org/warnings/special-props.html
I convert my component to useToggleLayer and had better result just because I can control the ref outside of the ToggleLayer instead of having to ```ref={mergeRef([triggerRef, externalRef])}``` So here is why my changes only apply to useToggleLayer.

Also, I'm sorry I didn't add docs to explain those new options. I didn't know where to add them... ToggleLayer explain props but useToggleLayer has one props that ToggleLayer doesn't.

Feel free to comment or edits. 