### PR TITLE
fixed issue-71 - delayed effects caused errors on unmount

### DIFF
--- a/packages/react-laag/src/useHover.ts
+++ b/packages/react-laag/src/useHover.ts
@@ -99,8 +99,6 @@ export function useHover({
 
   // make sure to clear timeout on unmount
   useEffect(() => {
-    const currentTimeout = timeout.current;
-
     function onScroll() {
       if (show && hideOnScroll) {
         removeTimeout();
@@ -122,8 +120,8 @@ export function useHover({
       window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("touchend", onTouchEnd, true);
 
-      if (currentTimeout) {
-        clearTimeout(currentTimeout);
+      if (timeout.current) {
+        clearTimeout(timeout.current);
       }
     };
   }, [show, hideOnScroll, removeTimeout]);


### PR DESCRIPTION
Fixed issue 71 https://github.com/everweij/react-laag/issues/71.

Unmounting components with delayed effects now don't perform state update on an unmounted component.