### PR TITLE
Add repository and homepage to npm

### DIFF
--- a/packages/react-laag/package.json
+++ b/packages/react-laag/package.json
@@ -3,6 +3,8 @@
   "license": "MIT",
   "name": "react-laag",
   "author": "Erik Verweij",
+  "homepage": "https://www.react-laag.com/",
+  "repository": "everweij/react-laag",
   "module": "dist/react-laag.esm.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Currently [npm page of react-laag](https://www.npmjs.com/package/react-laag) looks empty and to find this repository or docs people need to use Google.

These changes fix that, and npm will show links to the website and repository.