### PR TITLE
Fix incorrect window bounds

### DIFF
--- a/packages/react-laag/src/Bounds.ts
+++ b/packages/react-laag/src/Bounds.ts
@@ -157,8 +157,12 @@ export class Bounds implements IBounds {
    * @param environment reference to the window-object (needed when working with iframes for instance). Defaults to `window`
    */
   static fromWindow(environment?: Window): Bounds {
-    const { innerWidth: width = 0, innerHeight: height = 0 } =
-      environment || {};
+    const scrollingElement =
+      environment?.document.scrollingElement ??
+      environment?.document.documentElement;
+    const { clientWidth: width = 0, clientHeight: height = 0 } =
+      scrollingElement ?? {};
+
     return new Bounds({ width, height, right: width, bottom: height });
   }
 


### PR DESCRIPTION
Hi @everweij 👋 

thanks for this awesome library ❤️

While using it in my application, I noticed that the `containerOffset` doesn't take the scrollbar size into account when the scroll container is just the `<html>` element. Since the [scrollbar size is subtracted for all other scroll containers](https://github.com/everweij/react-laag/blob/cd151a5d145b48e1e903c804c4f9e9d9d18fc57d/packages/react-laag/src/SubjectsBounds.ts#L54) I figured this is a bug in the implementation (correct me if I'm wrong 😁).

Here are two screenshots that illustrate the problem.

Without fix and `containerOffset: 10`:

![Screenshot 2021-10-11 at 18 27 02](https://user-images.githubusercontent.com/781746/136934825-a4a57805-fc8e-4be0-8ce8-8376aff76814.jpg)

With fix and `containerOffset: 10`:

![Screenshot 2021-10-11 at 18 24 23](https://user-images.githubusercontent.com/781746/136934861-8f566306-3294-47a5-b1e7-57ae5947f1f4.jpg)

