### PR TITLE
Fix to prevent layer close on touch devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "react-laag",
   "version": "0.0.0",
   "license": "MIT",
   "workspaces": [

--- a/packages/react-laag/src/useHover.ts
+++ b/packages/react-laag/src/useHover.ts
@@ -106,19 +106,10 @@ export function useHover({
       }
     }
 
-    function onTouchEnd() {
-      if (show) {
-        removeTimeout();
-        setShow(false);
-      }
-    }
-
     window.addEventListener("scroll", onScroll, true);
-    window.addEventListener("touchend", onTouchEnd, true);
 
     return () => {
       window.removeEventListener("scroll", onScroll, true);
-      window.removeEventListener("touchend", onTouchEnd, true);
 
       if (timeout.current) {
         clearTimeout(timeout.current);


### PR DESCRIPTION
Hi @everweij 👋 This lib is awesome! 

We use the lib for tooltips and complex menus in our app. Currently it is not possible to interact with menus on touch devices - there is a corresponding feature request #77 

The problem in TouchEnd event handler in useHover hook that works on capture phase and close menu layer before any react event handler of our menu component. Seems there is no way to override it from outside:

```
function onTouchEnd() {
  if (show) {
    removeTimeout();
    setShow(false);
  }
}

window.addEventListener("touchend", onTouchEnd, true);
```

I think this event handler do nothing helpful cause onMouseLeave event handler also closes the layer. 

So this pull request do two things:

1) Removes this unnecessary touchEnd event handler
2) Adds name field to package.json ([gitpkg](https://github.com/ramasilveyra/gitpkg) validator requires this to use forked version in app.)

If the onTouchEnd event handler do something useful then it's better to setup it on bubble phase using react - in such way our custom menu event handlers will trigger first and can do stopPropagation.
